### PR TITLE
fix bug where 007 values starting with A weren't mapping correctly

### DIFF
--- a/lib/blacklight/marc/indexer/formats.rb
+++ b/lib/blacklight/marc/indexer/formats.rb
@@ -5,7 +5,7 @@ module Blacklight::Marc::Indexer::Formats
       v = v.upcase
       case
       when (v.start_with? 'A')
-        vals << (v == 'AD') ? 'Atlas' : 'Map'
+        vals << (v == 'AD' ? 'Atlas' : 'Map')
       when (v.start_with? 'C')
         case
         when (v == "CA")

--- a/spec/lib/indexer/formats_spec.rb
+++ b/spec/lib/indexer/formats_spec.rb
@@ -41,6 +41,14 @@ describe Blacklight::Marc::Indexer::Formats do
       subject.get_format.call(record,val,subject)
       expect(val).to eql(['TapeCartridge'])
     end
+    it 'should map for 007 field with AD value' do
+      record = double('Record')
+      allow(record).to receive(:fields).with(["245", "880"]).and_return([])
+      expect(record).to receive(:fields).with(["007", "880"]).and_return([MARC::ControlField.new('007','AD')])
+      val = []
+      subject.get_format.call(record,val,subject)
+      expect(val).to eql(['Atlas'])
+    end
     it 'should map for leader' do
       record = double('Record')
       allow(record).to receive(:fields).with(["245", "880"]).and_return([])


### PR DESCRIPTION
An operator precedence problem causes 007 values starting with A to map to true and false, instead of the correct string values 'Atlas' and 'Map'. I've included a test.