### PR TITLE
Fix undefined add_show_tools_partial.

### DIFF
--- a/lib/blacklight/marc/catalog.rb
+++ b/lib/blacklight/marc/catalog.rb
@@ -3,9 +3,9 @@ module Blacklight::Marc
     extend ActiveSupport::Concern
 
     included do
-      add_show_tools_partial(:librarian_view, if: :render_librarian_view_control?, define_method: false)
-      add_show_tools_partial(:refworks, if: :render_refworks_action?, modal: false)
-      add_show_tools_partial(:endnote, if: :render_endnote_action?, modal: false, path: :single_endnote_catalog_path, define_method: false)
+      blacklight_config.add_show_tools_partial(:librarian_view, if: :render_librarian_view_control?, define_method: false)
+      blacklight_config.add_show_tools_partial(:refworks, if: :render_refworks_action?, modal: false)
+      blacklight_config.add_show_tools_partial(:endnote, if: :render_endnote_action?, modal: false, path: :single_endnote_catalog_path, define_method: false)
     end
 
     def librarian_view


### PR DESCRIPTION
In upgrading a BL-6.14.1 site to Bl-7 I got the an undefined method
add_show_tools_partial for this gem.

This function will be deprecated in the next release. I'm not sure why
I got the errors, but updating the code to use the non deprecated
variant, fixed the issue for me.

This commit fixes this issue.