### PR TITLE
Don't use layout in librarian view if xhr

### DIFF
--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,10 +1,13 @@
 
 <div class="modal-header">
-  <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-  <h3 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h3>
+  <h1 class="modal-title"><%= t('blacklight.search.librarian_view.title') %></h1>
+  <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">×</span>
+  </button>
 </div>
 <%- if @response.documents.first.respond_to?(:to_marc) -%>
   <%= render "marc_view", document: @response.documents.first %>
 <%- else %>
   <%= t('blacklight.search.librarian_view.empty') %>
 <%- end -%>
+

--- a/lib/blacklight/marc/catalog.rb
+++ b/lib/blacklight/marc/catalog.rb
@@ -12,8 +12,10 @@ module Blacklight::Marc
       @response, deprecated_document = search_service.fetch params[:id]
       @document = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document, "The @document instance variable is deprecated and will be removed in Blacklight-marc 8.0")
       respond_to do |format|
-        format.html
-        format.js { render :layout => false }
+        format.html do
+          return render layout: false if request.xhr?
+          # Otherwise draw the full page
+        end 
       end
     end
 


### PR DESCRIPTION
Out of the box after running the quickstart installer, Librarian view modal included the site header and search bar.

<img width="781" alt="screen shot 2018-10-26 at 8 14 19 am" src="https://user-images.githubusercontent.com/1128631/47565686-59ce1580-d8f7-11e8-8efb-222b0a7cee51.png">

This removes the site header and search bar from librarian view modal following conventions from core BL.