### PR TITLE
Bump the engine cart version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,6 @@ require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 require 'engine_cart/rake_task'
 
-EngineCart.fingerprint_proc = EngineCart.rails_fingerprint_proc
-
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => [:ci]

--- a/blacklight-marc.gemspec
+++ b/blacklight-marc.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "capybara"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "engine_cart", "~> 1.0"
+  spec.add_development_dependency "engine_cart", "~> 2.0"
 end


### PR DESCRIPTION
[WIP] DO NOT MERGE - Required removing reference to `rails_fingerprint_proc` method that appears to have been removed from engine_cart.