### PR TITLE
Blacklight::Marc::Indexer#map_value accepts an array of translation m…

### DIFF
--- a/lib/blacklight/marc/indexer.rb
+++ b/lib/blacklight/marc/indexer.rb
@@ -45,9 +45,16 @@ class Blacklight::Marc::Indexer < Traject::Indexer::MarcIndexer
       accumulator.replace Array(accumulator[0]) # just take the first
     end
   end
+
+  # @deprecated Use traject directly instead
+  # @option options [Array<String>] :translation_map translation map keys
+  # if multiple translation maps are defined, precedence is given to earlier keys.
   def map_value block, options={}
     if translation_map_arg  = options.delete(:translation_map)
-      translation_map = Traject::TranslationMap.new(translation_map_arg)
+      translation_map_arg = Array(translation_map_arg)
+      translation_map = translation_map_arg.reduce(nil) do |map, arg|
+        map ? Traject::TranslationMap.new(arg).merge(map) : Traject::TranslationMap.new(arg)
+      end
     else
       translation_map = nil
     end
@@ -62,6 +69,8 @@ class Blacklight::Marc::Indexer < Traject::Indexer::MarcIndexer
       end
     end
   end
+  deprecation_deprecate map_value: 'use traject translation directly; map_value will be removed in 8.0'
+
   def trim block, options={}
     lambda do |record, accumulator|
       vals = []

--- a/spec/lib/traject_indexer_spec.rb
+++ b/spec/lib/traject_indexer_spec.rb
@@ -80,7 +80,9 @@ module TestIndexer
       acc << 'Unknown' # the default
       acc.replace Array(acc[0]) # just take the first
     end
-    to_field "mapped", map_value(literal('k'),translation_map:"test_formats")
+    to_field "mapped", map_value(literal('k'),translation_map:["test_formats","test_dewey"])
+    to_field "mapped_second", map_value(literal('000'),translation_map:["test_formats","test_dewey"])
+    to_field "mapped_third", map_value(literal('000'),translation_map:"test_dewey")
   end
   class Writer
     def self.accumulator=(acc)
@@ -127,6 +129,8 @@ describe Blacklight::Marc::Indexer do
       json = vals.first
       expect(json['format']).to eql(['Sound Disc'])
       expect(json['mapped']).to eql(['Image'])
+      expect(json['mapped_second']).to eql(['Bad Metadata'])
+      expect(json['mapped_third']).to eql(['000s - Computer Science, Information & General Works'])
     end
   end
 end

--- a/test_support/config/translation_maps/test_formats.properties
+++ b/test_support/config/translation_maps/test_formats.properties
@@ -20,3 +20,5 @@ m = Computer File
 h = Microform
 q = Musical Score
 v = Video
+# a check to make sure precedence works
+000 = Bad Metadata


### PR DESCRIPTION
…ap keys

This method is deprecated in 7.0
fixes #55