### PR TITLE
Draft: Requires blacklight/solr/document so as to "reopen" the namespace own…

### DIFF
--- a/lib/blacklight/marc/engine.rb
+++ b/lib/blacklight/marc/engine.rb
@@ -14,6 +14,8 @@ module Blacklight::Marc
     end
 
     initializer 'blacklight_marc.initialize' do |app|
+      require 'blacklight/solr/document'
+
       Mime::Type.register_alias "text/plain", :refworks_marc_txt
       Mime::Type.register_alias "text/plain", :openurl_kev
       Mime::Type.register "application/x-endnote-refer", :endnote


### PR DESCRIPTION
…ed by Blacklight and used by Blacklight Marc

I encountered a problem where the modules in the models directory were not getting loaded in my local blacklight application (see also #85) after upgrading to Rails 6.0. After reading the zeitwerk docs it seems like gems and engines that share a namespace need to be a bit careful, specifically one has to "reopen" an existing namespace, see https://github.com/fxn/zeitwerk/blob/master/README.md#reopening-third-party-namespaces. 

I am not sure that this is the right or even a good way of doing this, but it's a stab that does actually work for me. The zeitwerk docs don't provide examples for the Rails world and the Rails docs don't seem to mention this issue (or maybe I am missing it). 

I upgraded to blacklight 7.8 locally too because I noticed that some modules moved around in order to appease zeitwerk.