### PR TITLE
Accounts for the second argument that ActionDispatch::Routing::Polymo…

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -5,9 +5,9 @@ module BlacklightMarcHelper
     "http://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
   end
 
-  def refworks_solr_document_path opts = {}
-    if opts[:id]
-      refworks_export_url(url: solr_document_url(opts[:id], format: :refworks_marc_txt))
+  def refworks_solr_document_path args = {}, _options
+    if args[:id]
+      refworks_export_url(url: solr_document_url(args[:id], format: :refworks_marc_txt))
     end
   end
 


### PR DESCRIPTION
…rphicRoutes.polymorphic_method sends in Rails 6

After upgrading to Rails 6 (ruby 2.6.6) I began seeing this error on record view in my Blacklight catalog application:

```
16:37:46 web.1       | Completed 500 Internal Server Error in 89ms (ActiveRecord: 0.5ms | Allocations: 84826)
16:37:46 web.1       |
16:37:46 web.1       |
16:37:46 web.1       |
16:37:46 web.1       | ArgumentError - wrong number of arguments (given 2, expected 0..1):
16:37:46 web.1       |   app/views/catalog/_document_action.html.erb:2
16:37:46 web.1       |   app/views/catalog/_record_toolbar.html.erb:3
16:37:46 web.1       |   app/views/layouts/blacklight/base.html.erb:60
```

It looks like in Rails 6 the flagged code in this error lead to https://github.com/rails/rails/blob/v6.0.3/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L232

Adding a second unused arg to the method definition lets the page render and the error goes away.

I thought that this method really ought to have a suffix of `_url` instead of `_path` so I attempted to use that instead, the problem is that that would require a change in Blacklight to [`document_action_path`](https://github.com/projectblacklight/blacklight/blob/master/app/helpers/blacklight/component_helper_behavior.rb#L12) line 12 to be:

```rb
        url_for([action_opts.key, url_opts[:id], { path_only: false }])
```

And the you could have a method like:

```rb
  def refworks_solr_document_url args = {}, _options
    if args[:id]
      refworks_export_url(url: solr_document_url(args[:id], format: :refworks_marc_txt))
    end
  end
```

Not sure if maintainers have a preference?