### PR TITLE
Take first element if marcxml source is an array

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -59,7 +59,9 @@ module Blacklight::Solr::Document::Marc
   end
 
   def marc_record_from_marcxml
-    MARC::XMLReader.new(StringIO.new( fetch(_marc_source_field) )).to_a.first
+    marcxml = fetch(_marc_source_field)
+    marcxml = marcxml.first if marcxml.kind_of? Array
+    MARC::XMLReader.new(StringIO.new(marcxml)).to_a.first
   end
 
   def _marc_helper


### PR DESCRIPTION
I don't fully understand the origin of this situation, but when indexing
records in Marcxml, in a standard Blacklight 7 installation using
blacklight-marc, the source field (marc_ss) is stored as an array in Solr.
This causes all record visualizations and conversions fail, as the variable
type doesn't match the expected methods.  Indexing the same records as
iso2709 (binary) does not cause this error.

The workaround this patch provides is to check if the variable is an array
and, in that case, take the first element.