### PR TITLE
Using wtih_* syntax for passing modal values

### DIFF
--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,5 +1,5 @@
 <%= render Blacklight::System::ModalComponent.new do |component| %>
-  <% component.title { t('blacklight.search.librarian_view.title') } %>
+  <% component.with_title { t('blacklight.search.librarian_view.title') } %>
   <%- if @document.respond_to?(:to_marc) -%>
     <%= render "marc_view", document: @document %>
   <%- else %>


### PR DESCRIPTION
Resolves #109 

Using the new syntax for view_componenet 3 prevents test failure for Blacklight 8.