### PR TITLE
Use 264 for publisher info when 260 is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build Status](https://github.com/projectblacklight/blacklight-marc/actions/workflows/ruby.yml/badge.svg?branch=main)
 
-# Blacklight::Marc
+# Blacklight::Marc 
 
 MARC-specific enhancements for [Blacklight](https://github.com/projectblacklight/blacklight)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build Status](https://github.com/projectblacklight/blacklight-marc/actions/workflows/ruby.yml/badge.svg?branch=main)
 
-# Blacklight::Marc 
+# Blacklight::Marc
 
 MARC-specific enhancements for [Blacklight](https://github.com/projectblacklight/blacklight)
 

--- a/spec/models/concerns/blacklight/marc/document_export_spec.rb
+++ b/spec/models/concerns/blacklight/marc/document_export_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+class MockClass260
+  include Blacklight::Marc::DocumentExport
+
+  def to_marc
+    fields = [
+      { "100" => { "subfields" => [{ "a" => "Borja, Ronaldo I." }]}},
+      { "245" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => "Plasticity : ", "b" => "modeling & computation /", "c" => "Ronaldo I. Borja." }] } },
+      { "260" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => "Berlin :", "b" => "Springer,", "c" => "[2013]" }] } }
+    ]
+    MARC::Record.new_from_hash('fields' => fields)
+  end
+end
+
+class MockClass264
+  include Blacklight::Marc::DocumentExport
+
+  def to_marc
+    fields = [
+      { "100" => { "subfields" => [{ "a" => "Borja, Ronaldo I." }]}},
+      { "245" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => "Plasticity : ", "b" => "modeling & computation /", "c" => "Ronaldo I. Borja." }] } },
+      { "264" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => "Berlin :", "b" => "Springer,", "c" => "[2013]" }] } }
+    ]
+    MARC::Record.new_from_hash('fields' => fields)
+  end
+end
+
+RSpec.describe Blacklight::Marc::DocumentExport do
+  describe 'export citiations from 260 field' do
+    it 'exports citations in apa format' do
+      expect(MockClass260.new.export_as_apa_citation_txt).to include('(2013)')
+      expect(MockClass260.new.export_as_apa_citation_txt).to include('Berlin: Springer.')
+    end
+
+    it 'exports citations in mla format' do
+      expect(MockClass260.new.export_as_mla_citation_txt).to include('2013.')
+      expect(MockClass260.new.export_as_mla_citation_txt).to include('Berlin: Springer,')
+    end
+
+    it 'exports citations in Chicago format' do
+      expect(MockClass260.new.export_as_chicago_citation_txt).to include('2013.')
+      expect(MockClass260.new.export_as_chicago_citation_txt).to include('Berlin: Springer,')
+    end
+  end
+
+  describe 'export citations from 264 field' do
+    it 'exports citations in apa format' do
+      expect(MockClass264.new.export_as_apa_citation_txt).to include('(2013)')
+      expect(MockClass264.new.export_as_apa_citation_txt).to include('Berlin: Springer.')
+    end
+
+    it 'exports citations in mla format' do
+      expect(MockClass264.new.export_as_mla_citation_txt).to include('2013.')
+      expect(MockClass264.new.export_as_mla_citation_txt).to include('Berlin: Springer,')
+    end
+
+    it 'exports citations in Chicago format' do
+      expect(MockClass264.new.export_as_chicago_citation_txt).to include('2013.')
+      expect(MockClass264.new.export_as_chicago_citation_txt).to include('Berlin: Springer,')
+    end
+  end
+end


### PR DESCRIPTION
Resolves #107 

Citations for records created with publisher data in the 264 field are not displaying properly. This PR uses the 264 field when the 260 is not available to create the citation text.