### PR TITLE
Don't fail on citations when the 700 only has punctuation and spaces

### DIFF
--- a/app/models/concerns/blacklight/marc/document_export.rb
+++ b/app/models/concerns/blacklight/marc/document_export.rb
@@ -561,6 +561,7 @@ module Blacklight::Marc::DocumentExport
 
   def abbreviate_name(name)
     name_parts = name.split(", ")
+    return "" if name_parts.empty?
     first_name_parts = name_parts.last.split(" ")
     temp_name = name_parts.first + ", " + first_name_parts.first[0,1] + "."
     first_name_parts.shift
@@ -572,6 +573,7 @@ module Blacklight::Marc::DocumentExport
     name = clean_end_punctuation(name)
     return name unless name =~ /,/
     temp_name = name.split(", ")
+    return name if temp_name.empty?
     return temp_name.last + " " + temp_name.first
   end
 end

--- a/spec/models/concerns/blacklight/marc/document_export_spec.rb
+++ b/spec/models/concerns/blacklight/marc/document_export_spec.rb
@@ -26,6 +26,19 @@ class MockClass264
   end
 end
 
+class MockClassInvalid700
+  include Blacklight::Marc::DocumentExport
+
+  def to_marc
+    fields = [
+      { "100" => { "subfields" => [{ "a" => "Borja, Ronaldo I." }]}},
+      { "245" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => "Plasticity : ", "b" => "modeling & computation /", "c" => "Ronaldo I. Borja." }] } },
+      { "700" => { "ind1" => " ", "ind2" => " ", "subfields" => [{ "a" => ", ." }] } }
+    ]
+    MARC::Record.new_from_hash('fields' => fields)
+  end
+end
+
 RSpec.describe Blacklight::Marc::DocumentExport do
   describe 'export citiations from 260 field' do
     it 'exports citations in apa format' do
@@ -58,6 +71,23 @@ RSpec.describe Blacklight::Marc::DocumentExport do
     it 'exports citations in Chicago format' do
       expect(MockClass264.new.export_as_chicago_citation_txt).to include('2013.')
       expect(MockClass264.new.export_as_chicago_citation_txt).to include('Berlin: Springer,')
+    end
+  end
+
+  describe 'when the 700 only has punctuation and spaces' do
+    it 'exports citations in apa format' do
+      expect(MockClassInvalid700.new.export_as_apa_citation_txt).to include('Borja, R. I')
+      expect(MockClassInvalid700.new.export_as_apa_citation_txt).to include('Plasticity')
+    end
+
+    it 'exports citations in mla format' do
+      expect(MockClassInvalid700.new.export_as_mla_citation_txt).to include('Borja, Ronaldo I')
+      expect(MockClassInvalid700.new.export_as_mla_citation_txt).to include('Plasticity')
+    end
+
+    it 'exports citations in Chicago format' do
+      expect(MockClassInvalid700.new.export_as_chicago_citation_txt).to include('Borja, Ronaldo I')
+      expect(MockClassInvalid700.new.export_as_chicago_citation_txt).to include('Plasticity')
     end
   end
 end


### PR DESCRIPTION
We have a catalog record that has a 700#a ", ." that caused errors.