### PR TITLE
Use https for refworks link

### DIFF
--- a/app/helpers/blacklight_marc_helper.rb
+++ b/app/helpers/blacklight_marc_helper.rb
@@ -1,8 +1,6 @@
 module BlacklightMarcHelper
-
-  # This method should move to BlacklightMarc in Blacklight 6.x
   def refworks_export_url params = {}, *_
-    "http://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
+    "https://www.refworks.com/express/expressimport.asp?vendor=#{CGI.escape(params[:vendor] || application_name)}&filter=#{CGI.escape(params[:filter] || "MARC Format")}&encoding=65001" + (("&url=#{CGI.escape(params[:url])}" if params[:url]) || "")
   end
 
   def refworks_solr_document_path opts = {}, *_


### PR DESCRIPTION
This prevents an insecure content message displaying to the user.