### PR TITLE
Using DeprecatedConstantProxy without a Deprecator is deprecated

### DIFF
--- a/app/controllers/concerns/blacklight/marc/catalog.rb
+++ b/app/controllers/concerns/blacklight/marc/catalog.rb
@@ -9,13 +9,14 @@ module Blacklight::Marc
     end
 
     def librarian_view
+      deprecator = ActiveSupport::Deprecation.new
       if Blacklight::VERSION >= '8'
         @document = search_service.fetch(params[:id])
-        @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@document.response, "The @response instance variable is deprecated and will be removed in Blacklight-marc 8.0")
+        @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(@document.response, "The @response instance variable is deprecated and will be removed in Blacklight-marc 8.0", deprecator)
 
       else
         deprecated_response, @document = search_service.fetch(params[:id])
-        @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, "The @response instance variable is deprecated and will be removed in Blacklight-marc 8.0")
+        @response = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_response, "The @response instance variable is deprecated and will be removed in Blacklight-marc 8.0", deprecator)
       end
 
       respond_to do |format|


### PR DESCRIPTION
See https://github.com/rails/rails/commit/fc2dc7c8d3449e0d38cccab2e69647d8e1fb9b60